### PR TITLE
Fix form events

### DIFF
--- a/component.go
+++ b/component.go
@@ -59,8 +59,8 @@ func Render(c Component) (string, error) {
 			event, attribute := strings[1], strings[2]
 			if event == "value" {
 				return fmt.Sprintf(
-					`activekey="%s" value="{{ $template.%s }}" onkeyup="sendSetAttribute('%s', this.value)"`,
-					attribute, attribute, attribute)
+					`activekey="%s" value="{{ $template.%s }}" onkeyup="sendSetAttribute('%s', '%s', this.value)"`,
+					attribute, attribute, getComponentID(c), attribute)
 			}
 
 			return fmt.Sprintf(`on%s="send('%s.%s', this)"`,

--- a/main.go
+++ b/main.go
@@ -56,9 +56,9 @@ function send(method, self) {
 	ws.send(JSON.stringify(payload));
 }
 
-function sendSetAttribute(name, value) {
+function sendSetAttribute(componentID, name, value) {
 	var payload = {
-		method: "app.SetAttribute",
+		method: componentID+".SetAttribute",
 		key: name,
 		value: value,
 	};


### PR DESCRIPTION
Form events seem to have been broken since nested components were added. This PR fixes #10 by not defaulting to `app` for the component id in the event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pepper/11)
<!-- Reviewable:end -->
